### PR TITLE
mac_directory_fix

### DIFF
--- a/src/main/java/goistreamtoolredux/App.java
+++ b/src/main/java/goistreamtoolredux/App.java
@@ -1,7 +1,9 @@
 package goistreamtoolredux;
 
 import goistreamtoolredux.algorithm.CustomTimer;
+import goistreamtoolredux.algorithm.FileManager;
 import javafx.application.Application;
+import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
@@ -14,6 +16,12 @@ public class App extends Application {
     @Override
     public void init() {
         System.out.println("Starting Up");
+        try {
+            FileManager.verifyContent();
+        } catch (IOException exception) {
+            exception.printStackTrace();
+            Platform.exit();
+        }
     }
 
     @Override

--- a/src/main/java/goistreamtoolredux/algorithm/FileManager.java
+++ b/src/main/java/goistreamtoolredux/algorithm/FileManager.java
@@ -10,17 +10,9 @@ import java.util.stream.Stream;
 public class FileManager {
 
     //System independent path to output folder
-    protected static String outputPath = System.getProperty("user.dir") + File.separator + "output" + File.separator;
+    protected static String outputPath = getOutputPath();
     //System independent path to input folder
-    public static String inputPath = System.getProperty("user.dir") + File.separator + "input" + File.separator;
-    //Mac specific path to output folder
-    public static String outputPathMac = System.getProperty("user.home") + File.separator + "Library" + File.separator +
-            "Application Support" + File.separator + "GoIStreamToolRedux" + File.separator + "output" + File.separator;
-    //Mac specific path to input folder
-    private static String inputPathMac = System.getProperty("user.home") + File.separator + "Library" + File.separator +
-            "Application Support" + File.separator + "GoIStreamToolRedux" + File.separator + "input" + File.separator;
-    //Os Name
-    private static final String osName = System.getProperty("os.name").toLowerCase();
+    public static String inputPath = getInputPath();
 
     public static void main(String[] args) {
         System.out.println("Welcome to GoIStreamToolRedux CLI!\ntype 'help' for more info. Type 'verify' if first start.\nAwaiting User input...");
@@ -34,18 +26,20 @@ public class FileManager {
     }
 
     public static String getOutputPath() {
-        if (osName.contains("mac os")) {
-            return outputPathMac; //todo, will need to add this folder to verify command, so that it gets created
+        if (System.getProperty("os.name").toLowerCase().contains("mac os")) {
+            return System.getProperty("user.home") + File.separator + "Library" + File.separator +
+                    "Application Support" + File.separator + "GoIStreamToolRedux" + File.separator + "output" + File.separator; //todo, will need to add this folder to verify command, so that it gets created
         } else {
-            return outputPath;
+            return System.getProperty("user.dir") + File.separator + "output" + File.separator;
         }
     }
 
     public static String getInputPath() {
-        if (osName.contains("mac os")) {
-            return inputPathMac; //todo, will need to add this folder to verify command, so that it gets created
+        if (System.getProperty("os.name").toLowerCase().contains("mac os")) {
+            return System.getProperty("user.home") + File.separator + "Library" + File.separator +
+                    "Application Support" + File.separator + "GoIStreamToolRedux" + File.separator + "input" + File.separator; //todo, will need to add this folder to verify command, so that it gets created
         } else {
-            return inputPath;
+            return System.getProperty("user.dir") + File.separator + "input" + File.separator;
         }
     }
 

--- a/src/main/java/goistreamtoolredux/algorithm/FileManager.java
+++ b/src/main/java/goistreamtoolredux/algorithm/FileManager.java
@@ -13,6 +13,14 @@ public class FileManager {
     protected static String outputPath = System.getProperty("user.dir") + File.separator + "output" + File.separator;
     //System independent path to input folder
     public static String inputPath = System.getProperty("user.dir") + File.separator + "input" + File.separator;
+    //Mac specific path to output folder
+    public static String outputPathMac = System.getProperty("user.home") + File.separator + "Library" + File.separator +
+            "Application Support" + File.separator + "GoIStreamToolRedux" + File.separator + "output" + File.separator;
+    //Mac specific path to input folder
+    private static String inputPathMac = System.getProperty("user.home") + File.separator + "Library" + File.separator +
+            "Application Support" + File.separator + "GoIStreamToolRedux" + File.separator + "input" + File.separator;
+    //Os Name
+    private static final String osName = System.getProperty("os.name").toLowerCase();
 
     public static void main(String[] args) {
         System.out.println("Welcome to GoIStreamToolRedux CLI!\ntype 'help' for more info. Type 'verify' if first start.\nAwaiting User input...");
@@ -22,6 +30,22 @@ public class FileManager {
             System.out.print("> ");
             String input = scanner.nextLine();
             CLIParse(input);
+        }
+    }
+
+    public static String getOutputPath() {
+        if (osName.contains("mac os")) {
+            return outputPathMac; //todo, will need to add this folder to verify command, so that it gets created
+        } else {
+            return outputPath;
+        }
+    }
+
+    public static String getInputPath() {
+        if (osName.contains("mac os")) {
+            return inputPathMac; //todo, will need to add this folder to verify command, so that it gets created
+        } else {
+            return inputPath;
         }
     }
 

--- a/src/main/java/goistreamtoolredux/algorithm/FileManager.java
+++ b/src/main/java/goistreamtoolredux/algorithm/FileManager.java
@@ -25,6 +25,17 @@ public class FileManager {
         }
     }
 
+    /**
+     * Gets the (OS specific) application output folder path.
+     *
+     * This should be the current working directory of the application (where it was launched from)
+     * on all OS's except for Mac, where it will be
+     * the <code>~/Application Support/GoIStreamToolRedux/output/</code> folder.
+     *
+     * @return full path to output folder ending with separator char (typically '<code>/</code>'),
+     * so that content may be appended to it
+     * @see #getOutputPath()
+     */
     public static String getOutputPath() {
         if (System.getProperty("os.name").toLowerCase().contains("mac os")) {
             return System.getProperty("user.home") + File.separator + "Library" + File.separator +
@@ -34,6 +45,17 @@ public class FileManager {
         }
     }
 
+    /**
+     * Gets the (OS specific) application input folder path.
+     *
+     * This should be the current working directory of the application (where it was launched from)
+     * on all OS's except for Mac, where it will be
+     * the <code>~/Application Support/GoIStreamToolRedux/input/</code> folder.
+     *
+     * @return full path to input folder ending with separator char (typically '<code>/</code>'),
+     * so that content may be appended to it
+     * @see #getOutputPath()
+     */
     public static String getInputPath() {
         if (System.getProperty("os.name").toLowerCase().contains("mac os")) {
             return System.getProperty("user.home") + File.separator + "Library" + File.separator +
@@ -581,6 +603,11 @@ public class FileManager {
         return result;
     }
 
+    /**
+     * Gets an updated list of maps from the <code>maps.txt</code> file
+     * @return Each line of the maps.txt file, except empty lines
+     * @throws FileNotFoundException if <code>maps.txt</code> file was not found
+     */
     public static LinkedList<String> getAllMapsFromDisk() throws FileNotFoundException {
         //return list
         LinkedList<String> mapList = new LinkedList<>();

--- a/src/main/java/goistreamtoolredux/algorithm/FileManager.java
+++ b/src/main/java/goistreamtoolredux/algorithm/FileManager.java
@@ -28,7 +28,7 @@ public class FileManager {
     public static String getOutputPath() {
         if (System.getProperty("os.name").toLowerCase().contains("mac os")) {
             return System.getProperty("user.home") + File.separator + "Library" + File.separator +
-                    "Application Support" + File.separator + "GoIStreamToolRedux" + File.separator + "output" + File.separator; //todo, will need to add this folder to verify command, so that it gets created
+                    "Application Support" + File.separator + "GoIStreamToolRedux" + File.separator + "output" + File.separator;
         } else {
             return System.getProperty("user.dir") + File.separator + "output" + File.separator;
         }
@@ -37,7 +37,7 @@ public class FileManager {
     public static String getInputPath() {
         if (System.getProperty("os.name").toLowerCase().contains("mac os")) {
             return System.getProperty("user.home") + File.separator + "Library" + File.separator +
-                    "Application Support" + File.separator + "GoIStreamToolRedux" + File.separator + "input" + File.separator; //todo, will need to add this folder to verify command, so that it gets created
+                    "Application Support" + File.separator + "GoIStreamToolRedux" + File.separator + "input" + File.separator;
         } else {
             return System.getProperty("user.dir") + File.separator + "input" + File.separator;
         }


### PR DESCRIPTION
Fixes the bug where the Mac `.app` appliction would consider the user's home dir as the working dir for the input/output folder. This has been changed to the Application Support folder